### PR TITLE
Added contition to remove disabled repos from the fetched dict.

### DIFF
--- a/cvp_checks/tests/test_repo_list.py
+++ b/cvp_checks/tests/test_repo_list.py
@@ -11,6 +11,16 @@ def test_list_of_repo_on_nodes(local_salt_client, group):
                                       utils.node_groups[group]),
                                       'pillar.data', ['linux:system:repo'],
                                       expr_form='compound')
+
+    # check if some repos are disabled
+    for node in info_salt.keys():
+        repos = info_salt[node]["linux:system:repo"]
+        for repo in repos.keys():
+            repository = repos[repo]
+            if "enabled" in repository:
+                if not repository["enabled"]:
+                    repos.pop(repo)
+
     raw_actual_info = local_salt_client.cmd(
         group,
         'cmd.run',


### PR DESCRIPTION
Sometimes happens that "linux:system:repo" list has disabled repos,
for example: "mk_openstack": {"enabled": false} on some nodes. Currectly
the test test_list_of_repo_on_nodes() does not take this into account,
checks all repos and fails. Seems like disabled repos are accepted
and in this case test should not fail if there is no repo.

Added contition to remove disabled repos from the fetched dict.