### PR TITLE
Avoid wrong node grouping when nodes start from similar substring

### DIFF
--- a/cvp_checks/utils/__init__.py
+++ b/cvp_checks/utils/__init__.py
@@ -94,7 +94,7 @@ def calculate_groups():
         if node_name in skipped_groups:
             continue
         if expr_form == 'pcre':
-            nodes = local_salt_client.cmd(node_name,
+            nodes = local_salt_client.cmd('{}[0-9]{{1,3}}'.format(node_name),
                                           'test.ping',
                                           expr_form=expr_form)
         else:


### PR DESCRIPTION
Some environments have nodes that start from the similar substring,
e.g. ceph001 and ceph-mon01. For this example, the node name is
parsed as 'ceph' and 'ceph-mon' correctly. But 'ceph' pcre is
used for gathering OSD nodes where ceph001 and ceph-mon001 are
grouped togather by mistake. To avoid this, suggest to search with
more precise reg.exp.