### PR TITLE
Fixed K8S Node status test

### DIFF
--- a/cvp_checks/tests/test_k8s.py
+++ b/cvp_checks/tests/test_k8s.py
@@ -41,7 +41,7 @@ def test_k8s_get_nodes_status(local_salt_client):
             if 'STATUS' in line or 'proto' in line:
                 continue
             else:
-                if 'Ready' not in line:
+                if 'Ready' != line.split()[1]:
                     errors.append(line)
         break
     assert not errors, 'k8s is not healthy: {}'.format(json.dumps(


### PR DESCRIPTION
The node status in K8S cluster can be "Ready", "NotReady", etc.
If we check the substring "Ready" in "NotReady" status, it can
be found and the test passes. Need to check the entire word "Ready"
in the status field.

Example: test failed on my env:
AssertionError: k8s is not healthy:
      "cmp024    NotReady   node      103d      v1.8.5-4+77af14b530a816",
      "cmp046    NotReady   node      103d      v1.8.5-4+77af14b530a816"