### PR TITLE
http_proxy https_proxy env vars check

### DIFF
--- a/cvp_checks/utils/__init__.py
+++ b/cvp_checks/utils/__init__.py
@@ -19,14 +19,16 @@ class salt_remote:
 
         try:
             if "http_proxy" in os.environ:
-                raise Exception("PROXY_SET")
+                raise Exception("HTTP_PROXY_SET")
             if "https_proxy" in os.environ:
-                raise Exception("PROXY_SET")
+                raise Exception("HTTPS_PROXY_SET")
+            if "no_proxy" in os.environ:
+                raise Exception("NO_PROXY_SET")
         except Exception:
             print "\033[91m\nYou have proxy env variables configured " \
-            "(http_proxy or https_proxy). Please unset them " \
-            "both and restart if you have any problems " \
-            "with test execution.\033[0m\n"
+            "(http_proxy, https_proxy or no_proxy). Please make sure " \
+            "that you configured them correctly and restart if you " \
+            "have any problems with test execution.\033[0m\n"
             traceback.print_exc(file=sys.stdout)
 
         try:

--- a/cvp_checks/utils/__init__.py
+++ b/cvp_checks/utils/__init__.py
@@ -18,6 +18,18 @@ class salt_remote:
             accept_key_payload['arg'] = param
 
         try:
+            if "http_proxy" in os.environ:
+                raise Exception("PROXY_SET")
+            if "https_proxy" in os.environ:
+                raise Exception("PROXY_SET")
+        except Exception:
+            print "\033[91m\nYou have proxy env variables configured " \
+            "(http_proxy or https_proxy). Please unset them " \
+            "both and restart if you have any problems " \
+            "with test execution.\033[0m\n"
+            traceback.print_exc(file=sys.stdout)
+
+        try:
             login_request = requests.post(os.path.join(config['SALT_URL'],
                                                        'login'),
                                           headers=headers, data=login_payload)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pytest==3.0.6
+pytest
 requests
 flake8
 PyYAML


### PR DESCRIPTION
http_proxy https_proxy env vars check while client init to be sure that env vars are unset. Test execution is not skipped and client tries to reach salt master etc but raises exceprion about variables set so if you have anything broken - check logs and you will see that exception.