### PR TITLE
Fixed test_ui_alert_manager test

### DIFF
--- a/cvp_checks/tests/test_ui_addresses.py
+++ b/cvp_checks/tests/test_ui_addresses.py
@@ -46,7 +46,7 @@ def test_ui_prometheus(local_salt_client):
 
 
 def test_ui_alert_manager(local_salt_client):
-    IP = utils.get_monitoring_ip('cluster_public_host')
+    IP = utils.get_monitoring_ip('stacklight_monitor_address')
     result = local_salt_client.cmd(
         'keystone:server',
         'cmd.run',


### PR DESCRIPTION
Usually, the AlertManager is on the same host as the Prometheus,
but on the neighbor port 15011.