### PR TITLE
Add timeout parametr for contrail-status

### DIFF
--- a/cvp_checks/tests/test_contrail.py
+++ b/cvp_checks/tests/test_contrail.py
@@ -4,7 +4,7 @@ import json
 pytestmark = pytest.mark.usefixtures("contrail")
 
 STATUS_FILTER = r'grep -Pv "(==|^$|Disk|unix|support|boot|\*\*|FOR NODE)"'
-STATUS_COMMAND = "contrail-status"
+STATUS_COMMAND = "contrail-status -t 10"
 
 def get_contrail_status(salt_client, pillar, command, processor):
     return salt_client.cmd(


### PR DESCRIPTION
Without this -t parameter, on environments with more api workers it might result that contrail-api timeouted, because default timeout is 2 seconds and with more api workers it is not just enough. It can be bypassed by curling api or just adding parameter above " -t 10 ". Then results will be more accurate.